### PR TITLE
ci: make reports available for inspection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ executors:
 
 orbs:
   nx: nrwl/nx@1.6.1
+  codecov: codecov/codecov@3.2.4
 
 commands:
   prepare-dependencies:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
 
       - run:
           name: Run ESLint
-          command: yarn nx affected --base=$NX_BASE --head=$NX_HEAD --target=lint --parallel=3
+          command: yarn nx affected --base=$NX_BASE --head=$NX_HEAD --target=lint --parallel=3 --configuration=ci
 
       - run:
           name: Run tests and collect coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,12 @@ jobs:
           command: yarn nx-cloud stop-all-agents
           when: always
 
+      - store_test_results:
+          path: ./reports
+
+      - store_artifacts:
+          path: ./coverage
+
 workflows:
   version: 2
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ node_modules
 /.sass-cache
 /connect.lock
 /coverage
+/reports
 /libpeerconnection.log
 npm-debug.log
 yarn-error.log

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,30 @@
+# https://docs.codecov.com/docs/codecovyml-reference
+
+coverage:
+  status:
+    project:
+      default:
+        target: 70%
+        threshold: 20%
+
+    patch:
+      default:
+        target: 70%
+        threshold: 20%
+
+# https://docs.codecov.com/docs/flags
+
+flag_management:
+  default_rules:
+    carryforward: true
+
+    statuses:
+      - name_prefix: project-
+        type: project
+        target: 70%
+        threshold: 20%
+
+      - name_prefix: patch-
+        type: patch
+        target: 70%
+        threshold: 20%

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -1,3 +1,6 @@
 const nxPreset = require('@nrwl/jest/preset').default;
 
-module.exports = { ...nxPreset };
+module.exports = {
+  ...nxPreset,
+  coverageReporters: ['lcov', 'text'],
+};

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "husky": "^8.0.2",
     "jest": "28.1.1",
     "jest-environment-jsdom": "28.1.1",
+    "jest-junit": "^15.0.0",
     "lint-staged": "^13.0.3",
     "nx": "15.2.1",
     "prettier": "^2.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6845,6 +6845,16 @@ jest-haste-map@^28.1.1, jest-haste-map@^28.1.3:
   optionalDependencies:
     fsevents "^2.3.2"
 
+jest-junit@^15.0.0:
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-15.0.0.tgz#a47544ab42e9f8fe7ada56306c218e09e52bd690"
+  integrity sha512-Z5sVX0Ag3HZdMUnD5DFlG+1gciIFSy7yIVPhOdGUi8YJaI9iLvvBb530gtQL2CHmv0JJeiwRZenr0VrSR7frvg==
+  dependencies:
+    mkdirp "^1.0.4"
+    strip-ansi "^6.0.1"
+    uuid "^8.3.2"
+    xml "^1.0.1"
+
 jest-leak-detector@^28.1.3:
   version "28.1.3"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-28.1.3.tgz#a6685d9b074be99e3adee816ce84fd30795e654d"
@@ -7730,7 +7740,7 @@ mkdirp@^0.5.6:
   dependencies:
     minimist "^1.2.6"
 
-mkdirp@^1.0.3, mkdirp@~1.0.4:
+mkdirp@^1.0.3, mkdirp@^1.0.4, mkdirp@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -10672,6 +10682,11 @@ xml-name-validator@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
   integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## What?

Make reports available for inspection in CircleCI and CodeCov.

## Why?

To make it easier to inspect test summaries and coverage report artifacts on CI.

## How?

- Store test coverage reports and summary reports
- Using CodeCov orb

## Testing?

N/A

## Screenshots (optional)

N/A

## Anything Else?

N/A
