### PR TITLE
ci(web): make reports available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,10 @@ jobs:
       - store_artifacts:
           path: ./coverage
 
+      - codecov/upload:
+          file: ./coverage/apps/web/lcov.info
+          flags: web
+
 workflows:
   version: 2
 

--- a/apps/web/jest.config.ts
+++ b/apps/web/jest.config.ts
@@ -8,4 +8,15 @@ export default {
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/apps/web',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        suiteName: 'web app unit tests',
+        outputDirectory: 'reports/apps/web',
+        outputName: 'unit-test-results.xml',
+      },
+    ],
+  ],
 };

--- a/apps/web/project.json
+++ b/apps/web/project.json
@@ -56,6 +56,12 @@
       "outputs": ["{options.outputFile}"],
       "options": {
         "lintFilePatterns": ["apps/web/**/*.{ts,tsx,js,jsx}"]
+      },
+      "configurations": {
+        "ci": {
+          "format": "junit",
+          "outputFile": "reports/apps/web/eslint-results.xml"
+        }
       }
     }
   },


### PR DESCRIPTION
## What?

Make reports available in web app project.

## Why?

To make it easier to inspect test summaries and coverage report artifacts on CircleCI and CodeCov.

## How?

- Add generating junit report option to lint task
- Add junit reporter to jest config
- Add upload coverage report step in CI

## Testing?

N/A

## Screenshots (optional)

N/A

## Anything Else?

N/A
